### PR TITLE
Allow category/criteria to be absent for taxon-conservationlisting endpoint, unit test CommunityConservationListing POST endpoint.

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -50,10 +50,5 @@ jobs:
         pip install -r requirements/base.txt
         mkdir logs && touch logs/wastd.log
 
-    - name: Run tests and report test coverage
-      if: matrix.python-version == 3.7
-      run: fab test
-
     - name: Run parallel tests and skip test coverage
-      if: matrix.python-version != 3.7
       run: fab ptest

--- a/conservation/api.py
+++ b/conservation/api.py
@@ -254,11 +254,15 @@ class TaxonConservationListingViewSet(BatchUpsertViewSet):
             cat_ids = force_as_list(update_data.pop("category"))
             logger.debug("[API][create_one] Found categories {}".format(cat_ids))
             categories = [ConservationCategory.objects.get(id=x) for x in cat_ids if x != 'NA']
+        else:
+            categories = []
 
         if 'criteria' in update_data:
             crit_ids = force_as_list(update_data.pop("criteria"))
             logger.debug("[API][create_one] Found criteria {}".format(crit_ids))
             criteria = [ConservationCriterion.objects.get(id=x) for x in crit_ids if x != 'NA']
+        else:
+            criteria = []
 
         # Early exit 1: None value in unique data
         if None in unique_data.values():
@@ -274,8 +278,10 @@ class TaxonConservationListingViewSet(BatchUpsertViewSet):
 
         # Without the QA status deciding whether to update existing data:
         obj, created = self.model.objects.update_or_create(defaults=update_data, **unique_data)
-        obj.category.set(categories)  # TODO: must do individually or can do as list?
-        obj.criteria.set(criteria)
+        if categories:
+            obj.category.set(categories)  # TODO: must do individually or can do as list?
+        if criteria:
+            obj.criteria.set(criteria)
         obj.save()  # better save() than sorry
         obj.refresh_from_db()
         obj.save()  # to update cached fields

--- a/conservation/api.py
+++ b/conservation/api.py
@@ -382,12 +382,19 @@ class CommunityConservationListingViewSet(BatchUpsertViewSet):
         unique_data, update_data = self.split_data(data)
 
         # Pop category and criterion out update_data
-        cat_ids = force_as_list(update_data.pop("category"))
-        logger.debug("[API][create_one] Found categories {0}".format(cat_ids))
-        categories = [ConservationCategory.objects.get(id=x) for x in cat_ids if x != 'NA']
-        crit_ids = force_as_list(update_data.pop("criteria"))
-        logger.debug("[API][create_one] Found criteria {0}".format(crit_ids))
-        criteria = [ConservationCriterion.objects.get(id=x) for x in crit_ids if x != 'NA']
+        if 'category' in update_data:
+            cat_ids = force_as_list(update_data.pop("category"))
+            logger.debug("[API][create_one] Found categories {}".format(cat_ids))
+            categories = [ConservationCategory.objects.get(id=x) for x in cat_ids if x != 'NA']
+        else:
+            categories = []
+
+        if 'criteria' in update_data:
+            crit_ids = force_as_list(update_data.pop("criteria"))
+            logger.debug("[API][create_one] Found criteria {}".format(crit_ids))
+            criteria = [ConservationCriterion.objects.get(id=x) for x in crit_ids if x != 'NA']
+        else:
+            criteria = []
 
         # Early exit 1: None value in unique data
         if None in unique_data.values():
@@ -403,8 +410,10 @@ class CommunityConservationListingViewSet(BatchUpsertViewSet):
 
         # Without the QA status deciding whether to update existing data:
         obj, created = self.model.objects.update_or_create(defaults=update_data, **unique_data)
-        obj.category.set(categories)
-        obj.criteria.set(criteria)
+        if categories:
+            obj.category.set(categories)
+        if criteria:
+            obj.criteria.set(criteria)
         obj.save()  # better save() than sorry
         obj.refresh_from_db()
         obj.save()  # to update cached fields

--- a/conservation/api.py
+++ b/conservation/api.py
@@ -239,7 +239,6 @@ class TaxonConservationListingViewSet(BatchUpsertViewSet):
             logger.error("Exception {0}: taxon {1} not known,".format(e, data["taxon"]))
         return data
 
-
     def create_one(self, data):
         """POST: Create or update exactly one model instance.
 

--- a/conservation/tests/test_api.py
+++ b/conservation/tests/test_api.py
@@ -81,6 +81,23 @@ class ObservationGroupSerializerTests(TestCase):
         """Test the TaxonConservationListing POST endpoint behaves correctly
         """
         url = reverse('api:taxonconservationlisting-list')
-        data = {'source': 0, 'source_id': 'foobar', 'taxon': self.taxon.name_id, 'comments': 'Test comment', 'category': [], 'criteria': []}
+        data = {
+            'source': 0,
+            'source_id': 'foobar',
+            'taxon': self.taxon.name_id,
+            'comments': 'Test comment',
+            'category': [self.ccategory.pk],
+            'criteria': [self.ccriterion.pk]
+        }
+        resp = self.client.post(url, data=data)
+        self.assertEqual(resp.status_code, 201)
+        # Category or criteria can also be a single PK.
+        data['category'] = self.ccategory.pk
+        data['criteria'] = self.ccriterion.pk
+        resp = self.client.post(url, data=data)
+        self.assertEqual(resp.status_code, 201)
+        # Test with no categories or criteria.
+        data.pop('category')
+        data.pop('criteria')
         resp = self.client.post(url, data=data)
         self.assertEqual(resp.status_code, 201)

--- a/conservation/tests/test_api.py
+++ b/conservation/tests/test_api.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from django.test import TestCase
 import json
 from rest_framework.test import APIClient
+import uuid
 
 from taxonomy.models import Community, Taxon
 from conservation.models import (
@@ -83,7 +84,7 @@ class ObservationGroupSerializerTests(TestCase):
         url = reverse('api:taxonconservationlisting-list')
         data = {
             'source': 0,
-            'source_id': 'foobar',
+            'source_id': uuid.uuid4(),
             'taxon': self.taxon.name_id,
             'comments': 'Test comment',
             'category': [self.ccategory.pk],
@@ -92,11 +93,13 @@ class ObservationGroupSerializerTests(TestCase):
         resp = self.client.post(url, data=data)
         self.assertEqual(resp.status_code, 201)
         # Category or criteria can also be a single PK.
+        data['source_id'] = uuid.uuid4()
         data['category'] = self.ccategory.pk
         data['criteria'] = self.ccriterion.pk
         resp = self.client.post(url, data=data)
         self.assertEqual(resp.status_code, 201)
         # Test with no categories or criteria.
+        data['source_id'] = uuid.uuid4()
         data.pop('category')
         data.pop('criteria')
         resp = self.client.post(url, data=data)
@@ -108,7 +111,7 @@ class ObservationGroupSerializerTests(TestCase):
         url = reverse('api:communityconservationlisting-list')
         data = {
             'source': 0,
-            'source_id': 'foobar',
+            'source_id': uuid.uuid4(),
             'community': self.community.code,
             'comments': 'Test comment',
             'category': [self.ccategory.pk],
@@ -117,11 +120,13 @@ class ObservationGroupSerializerTests(TestCase):
         resp = self.client.post(url, data=data)
         self.assertEqual(resp.status_code, 201)
         # Category or criteria can also be a single PK.
+        data['source_id'] = uuid.uuid4()
         data['category'] = self.ccategory.pk
         data['criteria'] = self.ccriterion.pk
         resp = self.client.post(url, data=data)
         self.assertEqual(resp.status_code, 201)
         # Test with no categories or criteria.
+        data['source_id'] = uuid.uuid4()
         data.pop('category')
         data.pop('criteria')
         resp = self.client.post(url, data=data)

--- a/conservation/tests/test_api.py
+++ b/conservation/tests/test_api.py
@@ -77,7 +77,7 @@ class ObservationGroupSerializerTests(TestCase):
         resp = self.client.get(url, {'format': 'json'})
         self.assertEqual(resp.status_code, 200)
 
-    def test_post_endpoints(self):
+    def test_post_taxonconservationlisting(self):
         """Test the TaxonConservationListing POST endpoint behaves correctly
         """
         url = reverse('api:taxonconservationlisting-list')
@@ -85,6 +85,31 @@ class ObservationGroupSerializerTests(TestCase):
             'source': 0,
             'source_id': 'foobar',
             'taxon': self.taxon.name_id,
+            'comments': 'Test comment',
+            'category': [self.ccategory.pk],
+            'criteria': [self.ccriterion.pk]
+        }
+        resp = self.client.post(url, data=data)
+        self.assertEqual(resp.status_code, 201)
+        # Category or criteria can also be a single PK.
+        data['category'] = self.ccategory.pk
+        data['criteria'] = self.ccriterion.pk
+        resp = self.client.post(url, data=data)
+        self.assertEqual(resp.status_code, 201)
+        # Test with no categories or criteria.
+        data.pop('category')
+        data.pop('criteria')
+        resp = self.client.post(url, data=data)
+        self.assertEqual(resp.status_code, 201)
+
+    def test_post_communityconservationlisting(self):
+        """Test the CommunityConservationListing POST endpoint behaves correctly
+        """
+        url = reverse('api:communityconservationlisting-list')
+        data = {
+            'source': 0,
+            'source_id': 'foobar',
+            'community': self.community.code,
             'comments': 'Test comment',
             'category': [self.ccategory.pk],
             'criteria': [self.ccriterion.pk]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dbca-wa/wastd/281)
<!-- Reviewable:end -->
