### PR TITLE
Add filter for encounters with no survey in UI

### DIFF
--- a/observations/filters.py
+++ b/observations/filters.py
@@ -191,6 +191,13 @@ class TurtleNestEncounterFilter(FilterSet):
         label="Observed by",
         queryset=User.objects.filter(is_active=True).order_by("name"),
     )
+    survey = ChoiceFilter(
+        field_name="survey",
+        choices=(
+          ("null","<No survey>"),
+        ),
+        label="Survey",
+    )
     encounter_type = ChoiceFilter(
         field_name="encounter_type",
         choices=(

--- a/wastd/templates/navbar.html
+++ b/wastd/templates/navbar.html
@@ -77,6 +77,12 @@
                     <i class="fa-solid fa-table" aria-hidden="true"></i>
                     Track/nest encounters with no site
                 </a>
+                <a class="dropdown-item"
+                    href="{% url 'observations:turtlenestencounter-list' %}?survey=null"
+                    title="No Survey">
+                    <i class="fa-solid fa-table" aria-hidden="true"></i>
+                    Track/nest encounters with no survey
+                </a>
             </div>
         </li>
 


### PR DESCRIPTION
[Add filter for encounters with no survey in UI](https://github.com/dbca-wa/wastd/commit/741c802f17d4d2d5729189926f199dc02df43814)

Allow QA for missing surveys