### PR TITLE
Update application version to 2.3.1

### DIFF
--- a/kustomize/overlays/prod/kustomization.yaml
+++ b/kustomize/overlays/prod/kustomization.yaml
@@ -25,4 +25,4 @@ patches:
   - path: service_patch.yaml
 images:
   - name: ghcr.io/dbca-wa/wastd
-    newTag: 2.3.0
+    newTag: 2.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wastd"
-version = "2.3.0"
+version = "2.3.1"
 description = "Western Australian Sea Turtles Database"
 authors = [
   { name = "Florian Mayer", email = "florian.mayer@dbca.wa.gov.au" },


### PR DESCRIPTION

Updates the WASTD application version number from 2.3.0 to 2.3.1 in pyproject.toml.

The homepage version is populated from settings.VERSION_NO, which reads the project version