### PR TITLE
Fix PIT tag side autofill and validation

### DIFF
--- a/kustomize/overlays/prod/kustomization.yaml
+++ b/kustomize/overlays/prod/kustomization.yaml
@@ -25,4 +25,4 @@ patches:
   - path: service_patch.yaml
 images:
   - name: ghcr.io/dbca-wa/wastd
-    newTag: 2.3.0
+    newTag: 2.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wastd"
-version = "2.3.0"
+version = "2.3.1"
 description = "Western Australian Sea Turtles Database"
 authors = [
   { name = "Florian Mayer", email = "florian.mayer@dbca.wa.gov.au" },

--- a/wamtram2/static/js/tagValidation.js
+++ b/wamtram2/static/js/tagValidation.js
@@ -116,7 +116,7 @@ document.addEventListener('DOMContentLoaded', function() {
             if (type === 'recaptured_tag' && turtleId) {
                 url += `&turtle_id=${turtleId}&side=${side}`;
             } else if (type === 'recaptured_pit_tag' && turtleId) {
-                url += `&turtle_id=${turtleId}`;
+                url += `&turtle_id=${turtleId}&side=${side}`;
             } else if (type === 'recaptured_tag' && !turtleId) {
                 url += `&side=${side}`;
             }
@@ -248,10 +248,10 @@ document.addEventListener('DOMContentLoaded', function() {
     addValidationListener(tagInputs.newRightTagInput2, validationMessages.newRightTagMessage2, detailedMessages.newRightTagDetailedMessage2, 'new_tag');
     addValidationListener(tagInputs.newPitTagInput, validationMessages.newPitTagMessage, detailedMessages.newPitTagDetailedMessage, 'new_pit_tag');
     addValidationListener(tagInputs.newPitTagInput2, validationMessages.newPitTagMessage2, detailedMessages.newPitTagDetailedMessage2, 'new_pit_tag');
-    addValidationListener(tagInputs.recapturePitTagInput, validationMessages.recapturePitTagMessage, detailedMessages.recapturePitTagDetailedMessage, 'recaptured_pit_tag');
-    addValidationListener(tagInputs.recapturePitTagInput2, validationMessages.recapturePitTagMessage2, detailedMessages.recapturePitTagDetailedMessage2, 'recaptured_pit_tag');
+    addValidationListener(tagInputs.recapturePitTagInput, validationMessages.recapturePitTagMessage, detailedMessages.recapturePitTagDetailedMessage, 'recaptured_pit_tag','L');
+    addValidationListener(tagInputs.recapturePitTagInput2, validationMessages.recapturePitTagMessage2, detailedMessages.recapturePitTagDetailedMessage2, 'recaptured_pit_tag','R');
     addValidationListener(tagInputs.newPitTagInput3, validationMessages.newPitTagMessage3, detailedMessages.newPitTagDetailedMessage3, 'new_pit_tag');
     addValidationListener(tagInputs.newPitTagInput4, validationMessages.newPitTagMessage4, detailedMessages.newPitTagDetailedMessage4, 'new_pit_tag');
-    addValidationListener(tagInputs.recapturePitTagInput3, validationMessages.recapturePitTagMessage3, detailedMessages.recapturePitTagDetailedMessage3, 'recaptured_pit_tag');
-    addValidationListener(tagInputs.recapturePitTagInput4, validationMessages.recapturePitTagMessage4, detailedMessages.recapturePitTagDetailedMessage4, 'recaptured_pit_tag');
+    addValidationListener(tagInputs.recapturePitTagInput3, validationMessages.recapturePitTagMessage3, detailedMessages.recapturePitTagDetailedMessage3, 'recaptured_pit_tag','L');
+    addValidationListener(tagInputs.recapturePitTagInput4, validationMessages.recapturePitTagMessage4, detailedMessages.recapturePitTagDetailedMessage4, 'recaptured_pit_tag','R');
 });

--- a/wamtram2/templates/wamtram2/trtdataentry_form.html
+++ b/wamtram2/templates/wamtram2/trtdataentry_form.html
@@ -524,7 +524,6 @@
           <div id="recapturePIT">
             <h5><span style="color: blue; font-weight: bold">OLD</span> PIT Tag(s)</h5>
             <p style="color: red; font-style: italic; margin-bottom: 15px;">
-              Note: PIT tags will be placed into the recorded <strong>LEFT</strong> or <strong>RIGHT</strong> PIT tag field where possible.
             </p>
             <div class="row mt-2">
               <div class="col-md-6">

--- a/wamtram2/templates/wamtram2/trtdataentry_form.html
+++ b/wamtram2/templates/wamtram2/trtdataentry_form.html
@@ -524,7 +524,7 @@
           <div id="recapturePIT">
             <h5><span style="color: blue; font-weight: bold">OLD</span> PIT Tag(s)</h5>
             <p style="color: red; font-style: italic; margin-bottom: 15px;">
-              Note: If you searched using a <strong>RIGHT</strong> PIT tag, please manually copy it to the right PIT tag field.
+              Note: PIT tags will be placed into the recorded <strong>LEFT</strong> or <strong>RIGHT</strong> PIT tag field where possible.
             </p>
             <div class="row mt-2">
               <div class="col-md-6">

--- a/wamtram2/templates/wamtram2/trtdataentry_form.html
+++ b/wamtram2/templates/wamtram2/trtdataentry_form.html
@@ -1263,7 +1263,13 @@
                 setTagAndValidate('id_recapture_right_tag_id', cookieTagId);
             }
         } else if (cookieTagType === 'recapture_pit_tag') {
-            setTagAndValidate('id_recapture_pittag_id', cookieTagId);
+            
+            if (cookieTagSide === 'L') {
+                    setTagAndValidate('id_recapture_pittag_id', cookieTagId);
+                } else if (cookieTagSide === 'R') {
+                    setTagAndValidate('id_recapture_pittag_id_2', cookieTagId);
+                }
+
         }
     }
 

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -481,7 +481,10 @@ class TrtDataEntryFormView(LoginRequiredMixin, FormView):
                 elif tag_side == "R":
                     initial["recapture_right_tag_id"] = tag_id
             elif tag_type == "recapture_pit_tag":
-                initial["recapture_pittag_id"] = tag_id
+                if tag_side == "L":
+                    initial["recapture_pittag_id"] = tag_id
+                elif tag_side == "R":
+                    initial["recapture_pittag_id_2"] = tag_id
 
         if batch_id:
             try:
@@ -998,6 +1001,23 @@ class FindTurtleView(LoginRequiredMixin, View):
                     if pit_tag:
                         turtle = pit_tag.turtle
                         tag_type = "recapture_pit_tag"
+                        
+                        latest_pit_record = (
+                            TrtRecordedPitTags.objects.filter(
+                                pittag_id=pit_tag
+                            )
+                            .exclude(pit_tag_position__isnull=True)
+                            .order_by("-recorded_pittag_id")
+                            .first()
+                        )
+
+                        if latest_pit_record:
+                            if latest_pit_record.pit_tag_position == "LF":
+                                tag_side = "L"
+                            elif latest_pit_record.pit_tag_position == "RF":
+                                tag_side = "R"
+
+
                     else:
                         tag_type = "unknown_tag"
 

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -1771,6 +1771,7 @@ class ValidateTagView(View):
         """
         turtle_id = request.GET.get("turtle_id")
         tag = request.GET.get("tag")
+        side = request.GET.get("side")
 
         if not tag:
             return JsonResponse({"valid": False, "message": "Missing parameters"})
@@ -1820,7 +1821,36 @@ class ValidateTagView(View):
                             }
                         )
                     else:
-                        return JsonResponse({"valid": True})
+                        
+                        actual_side = None
+
+                        latest_record = (
+                            TrtRecordedPitTags.objects.filter(
+                                pittag_id=pit_tag
+                            )
+                            .exclude(pit_tag_position__isnull=True)
+                            .order_by("-recorded_pittag_id")
+                            .first()
+                        )
+
+                        if latest_record:
+                            if latest_record.pit_tag_position == "LF":
+                                actual_side = "L"
+                            elif latest_record.pit_tag_position == "RF":
+                                actual_side = "R"
+
+                        wrong_side = False
+
+                        if actual_side and side:
+                            wrong_side = actual_side.lower() != side.lower()
+
+                        return JsonResponse(
+                            {
+                                "valid": True,
+                                "wrong_side": wrong_side,
+                            }
+                        )
+
                 else:
                     return JsonResponse({"valid": False, "message": "PIT tag not found", "tag_not_found": True})
             else:


### PR DESCRIPTION
Fixes PIT tag side handling during WAMTRAM data entry.

Changes:
- Derive PIT tag side from TrtRecordedPitTags.pit_tag_position.
- Map LF/RF to left/right form fields during recapture entry creation.
- Pass PIT tag field side to validation.
- Show wrong-side validation when RF PIT tags are entered in left PIT fields, or LF PIT tags are entered in right PIT fields.
- Delete the two notes that were previously used as temporary hints.