### PR TITLE
T024 Auto populate old flipper tag check after tag search

### DIFF
--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -476,6 +476,7 @@ class TrtDataEntryFormView(LoginRequiredMixin, FormView):
         # If a tag is selected, populate the form with the tag data
         if tag_id and tag_type:
             if tag_type == "recapture_tag":
+                initial["flipper_tag_check"] = TrtYesNo.objects.get(code="Y")
                 if tag_side == "L":
                     initial["recapture_left_tag_id"] = tag_id
                 elif tag_side == "R":


### PR DESCRIPTION
## Summary

Automatically sets "Does turtle have old FLIPPER tag(s)?" to "Yes" when a turtle is found using a flipper tag search.

## Changes

- Detects when the data entry form is opened from a recaptured flipper tag search.
- Sets `flipper_tag_check` to `Yes` during form initialisation.
- Preserves existing old left/right flipper tag auto-population behaviour.

## Testing

Tested by searching for a turtle using a flipper tag and confirming that:

- The new data entry form opens successfully.
- "Does turtle have old FLIPPER tag(s)?" is automatically set to "Yes".
- The searched flipper tag still populates into the correct old left/right flipper tag field.

## Notes

No database schema changes or migrations are required.