### PR TITLE
Fix/t008 Added year validation for Volunteer users

### DIFF
--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -580,6 +580,20 @@ class TrtDataEntryFormView(LoginRequiredMixin, FormView):
         return initial
 
     def form_valid(self, form):
+        
+        observation_date = form.cleaned_data.get("observation_date")
+
+        if (
+            self.request.user.groups.filter(name="WAMTRAM2_VOLUNTEER").exists()
+            and observation_date
+            and observation_date.year != timezone.now().year
+        ):
+            form.add_error(
+                "observation_date",
+                "Volunteers can only enter observations for the current year."
+            )
+            return self.form_invalid(form)
+
         batch_id = form.cleaned_data["entry_batch"].entry_batch_id
         do_not_process_cookie_name = f"{batch_id}_do_not_process"
         do_not_process_cookie_value = self.request.COOKIES.get(do_not_process_cookie_name)


### PR DESCRIPTION
Implemented validation to restrict Volunteer users from entering observations outside the current calendar year.
- Volunteer users can only enter observations for the current year.
- Team Leaders, Staff and Superusers can enter observations for any year.
- Added a validation message on the Observation Date & Time field when validation fails.
- No database changes required.

Manual Testing locally:
- Verified Volunteer users cannot save observations dated outside the current year.
- Verified Volunteer users can save observations dated within the current year.
- Verified Superusers can save observations from any year.
