### PR TITLE
T006 Add PX to old flipper tag state option

### DIFF
--- a/wamtram2/forms.py
+++ b/wamtram2/forms.py
@@ -365,7 +365,7 @@ class TrtDataEntryForm(forms.ModelForm):
         self.fields["new_right_tag_state_2"].queryset = new_tag_states
 
         # Filter the queryset for recapture (old) tag fields
-        old_tag_state_order = ["P_OK", "P", "RC", "RN", "OO", "R", "#"]
+        old_tag_state_order = ["P_OK", "P","PX", "RC", "RN", "OO", "R", "#"]
 
         old_tag_state_order_case = Case(
             *[When(tag_state=state, then=pos) for pos, state in enumerate(old_tag_state_order)],


### PR DESCRIPTION
## Summary

The "Present Obs - Tag#s not read" tag state (PX) was available in the database but was not included in the list of Old Flipper Tag State options shown in the Data Entry form.

This change adds PX to the available old tag state options so users can record cases where a flipper tag was observed but the tag number could not be read.

## Changes

- Added the PX tag state ("Present Obs - Tag#s not read") to the `old_tag_state_order` list.
- The PX option is now available in the Old Flipper Tag State dropdown.

## Testing

Tested using the Data Entry form:

- Confirmed "Present Obs - Tag#s not read" appears in the dropdown.
- Confirmed the state can be selected without entering a flipper tag number.
- Confirmed the record saves successfully.
- Confirmed the selected state is retained when reopening the record.
- Confirmed the record can be edited and saved again without issues.