### PR TITLE
Fix/T058 Resolved an issue preventing the Flipper tag management tool from loading

### DIFF
--- a/wamtram2/templates/wamtram2/dud_tag_manage.html
+++ b/wamtram2/templates/wamtram2/dud_tag_manage.html
@@ -82,7 +82,13 @@
                                         <td>{{ entry_data.tag_type|title }}</td>
                                         <td>
                                             {% if entry_data.tag_type|startswith:'flipper' %}
-                                                <a href="{% url 'admin:wamtram2_trttags_change' entry_data.tag_id %}">{{ entry_data.tag_id }}</a>
+                                                {% if entry_data.tag_id %}
+                                                    <a href="{% url 'admin:wamtram2_trttags_change' entry_data.tag_id %}">
+                                                        {{ entry_data.tag_id }}
+                                                    </a>
+                                                {% else %}
+                                                    N/A
+                                                {% endif %}
                                             {% elif entry_data.tag_type|startswith:'pit' %}
                                                 <a href="{% url 'admin:wamtram2_trtpittags_change' entry_data.tag_id %}">{{ entry_data.tag_id }}</a>
                                             {% else %}

--- a/wamtram2/templates/wamtram2/flipper_tags_list.html
+++ b/wamtram2/templates/wamtram2/flipper_tags_list.html
@@ -61,9 +61,13 @@
                     {% for tag in flipper_tags %}
                         <tr>
                             <td>
-                                <a href="{% url 'admin:wamtram2_trttags_change' tag.tag_id %}">
-                                    {{ tag.tag_id }}
-                                </a>
+                                {% if tag.tag_id %}
+                                    <a href="{% url 'admin:wamtram2_trttags_change' tag.tag_id %}">
+                                        {{ tag.tag_id }}
+                                    </a>
+                                {% else %}
+                                    -
+                                {% endif %}
                             </td>
                             <td>
                                 {% if tag.turtle %}


### PR DESCRIPTION
The page failed when attempting to generate admin links for records with missing tag IDs. Added validation to ensure links are only rendered when a valid tag ID is present.

This restores access to the Flipper tag management tool and prevents the page from failing when historical records contain incomplete data (Turtle_id：77530).
