### PR TITLE
Fix/t003

### DIFF
--- a/wamtram2/templates/includes/tag_filter.html
+++ b/wamtram2/templates/includes/tag_filter.html
@@ -1,20 +1,46 @@
-<form method="get" class="form-inline">
-    <div class="form-group mr-3">
-        <label for="status" class="mr-2">Status:</label>
-        <select name="status" id="status" class="form-control">
-            <option value="">All Statuses</option>
-            {% for status in status_choices %}
-                <option value="{{ status.pk }}" {% if status.pk|stringformat:"s" == current_status %}selected{% endif %}>
-                    {{ status }}
-                </option>
-            {% endfor %}
-        </select>
+<form method="get">
+    <div class="row align-items-end">
+        <div class="col-md-3">
+            <label for="status" class="mr-2 font-weight-bold">Status:</label>
+            <select name="status" id="status" class="form-control">
+                <option value="">All Statuses</option>
+                {% for status in status_choices %}
+                    <option value="{{ status.pk }}" {% if status.pk|stringformat:"s" == current_status %}selected{% endif %}>
+                        {{ status }}
+                    </option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-md-3">      
+            <label for="search" class="mr-2 font-weight-bold">
+                        Tag / Turtle / Custodian:
+                    </label>
+            <input type="text" name="search" class="form-control" 
+                placeholder="{{ placeholder }}" 
+                value="{{ search_term }}">
+        </div>
+    
+    <!-- Add Issue Location Search -->
+        <div class="col-md-3">
+            <label for="issueLocation" class="mr-2 font-weight-bold">
+                        Issue Location:
+                    </label>
+            <div class="search-container">
+                <input type="text"
+                    id="issueLocation"
+                    name="issue_location"
+                    class="form-control"
+                    placeholder="Issue Location"
+                    value="{{ current_issue_location }}"
+                    autocomplete="off">
+
+                <div id="issueLocationSearchResults"
+                    class="search-results">
+                </div>
+            </div>
+        </div>
+
+        <button type="submit" class="btn btn-primary mr-2">Apply Filters</button>
+        <a href="{% url clear_url %}" class="btn btn-secondary">Clear Filters</a>
     </div>
-    <div class="form-group mr-3">
-        <input type="text" name="search" class="form-control" 
-            placeholder="{{ placeholder }}" 
-            value="{{ search_term }}">
-    </div>
-    <button type="submit" class="btn btn-primary mr-2">Apply Filters</button>
-    <a href="{% url clear_url %}" class="btn btn-secondary">Clear Filters</a>
 </form>

--- a/wamtram2/templates/wamtram2/flipper_tags_list.html
+++ b/wamtram2/templates/wamtram2/flipper_tags_list.html
@@ -101,3 +101,93 @@
         </div>
     </div>
 {% endblock %}
+
+
+{% block extra_script %}
+<script>
+ // Setup issue location search
+    function setupIssueLocationSearch(inputId, resultsId) {
+        const input = document.getElementById(inputId);
+        const searchResults = document.getElementById(resultsId);
+        
+        if (!input || !searchResults) {
+                return;
+            }
+
+        let isSelecting = false;
+        let debounceTimer;
+
+        function debounce(func, wait) {
+            return function executedFunction(...args) {
+                const later = () => {
+                    clearTimeout(debounceTimer);
+                    func(...args);
+                };
+
+                clearTimeout(debounceTimer);
+                debounceTimer = setTimeout(later, wait);
+            };
+        }
+
+        const performSearch = debounce(async (searchTerm) => {
+            if (searchTerm.length >= 2) {
+                try {
+                    const response = await fetch(
+                        `/wamtram2/search-issue-locations/?q=${encodeURIComponent(searchTerm)}`
+                    );
+
+                    const data = await response.json();
+
+                    searchResults.innerHTML = '';
+
+                    if (data.length > 0) {
+                        searchResults.style.display = 'block';
+
+                        data.forEach(location => {
+                            const div = document.createElement('div');
+
+                            div.className = 'search-result';
+                            div.textContent = location.issue_location;
+
+                            div.addEventListener('click', () => {
+                                isSelecting = true;
+                                input.value = location.issue_location;
+                                searchResults.style.display = 'none';
+                                isSelecting = false;
+                            });
+
+                            searchResults.appendChild(div);
+                        });
+                    } else {
+                        searchResults.style.display = 'none';
+                    }
+                } catch (error) {
+                    console.error('Search error:', error);
+                    showMessage('Error performing search', 'danger');
+                }
+            } else {
+                searchResults.style.display = 'none';
+            }
+        }, 300);
+
+        input.addEventListener('input', function() {
+            if (isSelecting) return;
+            performSearch(this.value);
+        });
+
+        document.addEventListener('click', function(e) {
+            if (e.target !== input && !searchResults.contains(e.target)) {
+                searchResults.style.display = 'none';
+            }
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+        setupIssueLocationSearch(
+            'issueLocation',
+            'issueLocationSearchResults'
+        );
+    });
+
+</script>
+{% endblock %}

--- a/wamtram2/templates/wamtram2/tag_register.html
+++ b/wamtram2/templates/wamtram2/tag_register.html
@@ -328,7 +328,6 @@
         );
     });
 
-
     // Form submission handler
     document.getElementById('tagRegisterForm').addEventListener('submit', async function(e) {
         e.preventDefault();

--- a/wamtram2/templates/wamtram2/tag_register.html
+++ b/wamtram2/templates/wamtram2/tag_register.html
@@ -80,7 +80,20 @@
                 <!-- Location and Personnel -->
                 <div class="form-group">
                     <label for="issueLocation">Issue Location</label>
-                    <input type="text" class="form-control form-control-sm" id="issueLocation" name="issue_location" required>
+
+                    <div class="search-container">
+                        <input type="text"
+                            class="search-field form-control form-control-sm"
+                            id="issueLocation"
+                            name="issue_location"
+                            placeholder="Search or enter issue location..."
+                            autocomplete="off"
+                            required>
+
+                        <div id="issueLocationSearchResults"
+                            class="search-results">
+                        </div>
+                    </div>
                 </div>
 
                 <div class="row mb-3">
@@ -235,6 +248,86 @@
             }
         });
     }
+    
+    // Setup issue location search
+    function setupIssueLocationSearch(inputId, resultsId) {
+    const input = document.getElementById(inputId);
+    const searchResults = document.getElementById(resultsId);
+    let isSelecting = false;
+    let debounceTimer;
+
+    function debounce(func, wait) {
+        return function executedFunction(...args) {
+            const later = () => {
+                clearTimeout(debounceTimer);
+                func(...args);
+            };
+
+            clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(later, wait);
+        };
+    }
+
+    const performSearch = debounce(async (searchTerm) => {
+        if (searchTerm.length >= 2) {
+            try {
+                const response = await fetch(
+                    `/wamtram2/search-issue-locations/?q=${encodeURIComponent(searchTerm)}`
+                );
+
+                const data = await response.json();
+
+                searchResults.innerHTML = '';
+
+                if (data.length > 0) {
+                    searchResults.style.display = 'block';
+
+                    data.forEach(location => {
+                        const div = document.createElement('div');
+
+                        div.className = 'search-result';
+                        div.textContent = location.issue_location;
+
+                        div.addEventListener('click', () => {
+                            isSelecting = true;
+                            input.value = location.issue_location;
+                            searchResults.style.display = 'none';
+                            isSelecting = false;
+                        });
+
+                        searchResults.appendChild(div);
+                    });
+                } else {
+                    searchResults.style.display = 'none';
+                }
+            } catch (error) {
+                console.error('Search error:', error);
+                showMessage('Error performing search', 'danger');
+            }
+        } else {
+            searchResults.style.display = 'none';
+        }
+    }, 300);
+
+    input.addEventListener('input', function() {
+        if (isSelecting) return;
+        performSearch(this.value);
+    });
+
+    document.addEventListener('click', function(e) {
+        if (e.target !== input && !searchResults.contains(e.target)) {
+            searchResults.style.display = 'none';
+        }
+    });
+}
+
+    document.addEventListener('DOMContentLoaded', function() {
+        setupIssueLocationSearch(
+            'issueLocation',
+            'issueLocationSearchResults'
+        );
+    });
+
 
     // Form submission handler
     document.getElementById('tagRegisterForm').addEventListener('submit', async function(e) {
@@ -314,5 +407,6 @@
             });
         });
     });
+    
 </script>
 {% endblock %}

--- a/wamtram2/urls.py
+++ b/wamtram2/urls.py
@@ -79,4 +79,5 @@ urlpatterns = [
     path("curation/nesting-season-stats/", views.NestingSeasonStatsView.as_view(), name="nesting_season_stats"),
     path("batch-create-batches/", views.BatchCreateBatchesView.as_view(), name="batch_create_batches"),
     path("batches-review/", views.BatchesReviewView.as_view(), name="batches_review"),
-]
+    path( "search-issue-locations/", views.search_issue_locations, name="search-issue-locations"),
+]  

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -3802,14 +3802,12 @@ class PitTagsListView(LoginRequiredMixin, UserPassesTestMixin, PaginateMixin, Li
         status = self.request.GET.get("status")
         if status:
             queryset = queryset.filter(pit_tag_status=status)
-
+        
         issue_location = self.request.GET.get("issue_location")
-
         if issue_location:
             queryset = queryset.filter(
                 issue_location__icontains=issue_location
             )
-
         return queryset
 
     def get_context_data(self, **kwargs):
@@ -3865,7 +3863,6 @@ class FlipperTagsListView(LoginRequiredMixin, UserPassesTestMixin, PaginateMixin
             )
 
         status = self.request.GET.get("status")
-        
         if status:
             queryset = queryset.filter(tag_status_id=status)
 

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -3228,6 +3228,39 @@ def search_templates(request):
         return JsonResponse(data, safe=False)
     return JsonResponse([], safe=False)
 
+def search_issue_locations(request):
+    query = request.GET.get("q", "").strip()
+
+    flipper_locations = TrtTags.objects.filter(
+        issue_location__istartswith=query
+    ).exclude(
+        issue_location__isnull=True
+    ).exclude(
+        issue_location=""
+    ).values_list(
+        "issue_location",
+        flat=True
+    )
+
+    pit_locations = TrtPitTags.objects.filter(
+        issue_location__istartswith=query
+    ).exclude(
+        issue_location__isnull=True
+    ).exclude(
+        issue_location=""
+    ).values_list(
+        "issue_location",
+        flat=True
+    )
+
+    locations = sorted(
+        set(list(flipper_locations) + list(pit_locations))
+    )[:20]
+
+    return JsonResponse(
+        [{"issue_location": location} for location in locations],
+        safe=False,
+    )
 
 class BatchCodeManageView(View):
     template_name = "wamtram2/batch_detail_manage.html"
@@ -3770,6 +3803,13 @@ class PitTagsListView(LoginRequiredMixin, UserPassesTestMixin, PaginateMixin, Li
         if status:
             queryset = queryset.filter(pit_tag_status=status)
 
+        issue_location = self.request.GET.get("issue_location")
+
+        if issue_location:
+            queryset = queryset.filter(
+                issue_location__icontains=issue_location
+            )
+
         return queryset
 
     def get_context_data(self, **kwargs):
@@ -3782,6 +3822,7 @@ class PitTagsListView(LoginRequiredMixin, UserPassesTestMixin, PaginateMixin, Li
                 "search_term": self.request.GET.get("search", ""),
                 "current_status": self.request.GET.get("status", ""),
                 "status_choices": TrtPitTagStatus.objects.all(),
+                "current_issue_location": self.request.GET.get("issue_location", ""),
             }
         )
         return context
@@ -3803,6 +3844,7 @@ class FlipperTagsListView(LoginRequiredMixin, UserPassesTestMixin, PaginateMixin
                 "current_status": self.request.GET.get("status", ""),
                 "status_choices": TrtTagStatus.objects.all(),
                 "page_title": "Flipper Tags - " + settings.SITE_TITLE,
+                "current_issue_location": self.request.GET.get("issue_location", ""),
             }
         )
         return context
@@ -3823,9 +3865,15 @@ class FlipperTagsListView(LoginRequiredMixin, UserPassesTestMixin, PaginateMixin
             )
 
         status = self.request.GET.get("status")
+        
         if status:
             queryset = queryset.filter(tag_status_id=status)
 
+        issue_location = self.request.GET.get("issue_location")
+        if issue_location:
+            queryset = queryset.filter(
+                issue_location__icontains=issue_location
+            )
         return queryset
 
 


### PR DESCRIPTION
## Summary

Adds Issue Location search and filtering support across tag management pages.

### Changes

#### Tag Register
- Added Issue Location autocomplete suggestions based on existing tag records.
- Added `search_issue_locations` endpoint.
- Reuses historical Issue Location values from both Flipper Tags and PIT Tags.
- Allows selection from existing locations while still permitting manual entry.

#### Flipper Tags Curation
- Added Issue Location filter field.
- Added autocomplete suggestions for Issue Location.
- Added filtering by Issue Location.

#### PIT Tags Curation
- Added filtering by Issue Location.
- Reuses the same filter component and autocomplete endpoint.

### Notes

- No database changes required.
- Existing `issue_location` fields are reused.
- Users can select an existing Issue Location value or enter a new one.
- Autocomplete suggestions are generated from previously recorded Issue Location values in Flipper Tag and PIT Tag records.