### PR TITLE
T059 Restore third admin dashboard column

### DIFF
--- a/wastd/dashboard.py
+++ b/wastd/dashboard.py
@@ -2,6 +2,7 @@ from grappelli.dashboard import modules, Dashboard
 
 
 class AdminDashboard(Dashboard):
+    columns = 3
     def init_with_context(self, context):
         self.children.append(
             modules.Group(


### PR DESCRIPTION
## Summary

Restore the third column in the Grappelli admin dashboard.

## Reason

The third admin dashboard column used for user and permission management
was no longer visible from the admin homepage, although the underlying
URLs remained accessible.

## Result

The user management panel is visible again and the dashboard layout
matches the previous v2.2.x behaviour.