### PR TITLE
T057 Handle orphaned observation references in batches

### DIFF
--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -255,7 +255,7 @@ class EntryBatchDetailView(LoginRequiredMixin, FormMixin, ListView):
         )
 
         entries = TrtDataEntry.objects.filter(entry_batch_id=batch.entry_batch_id)
-        all_entries_processed = all(entry.observation_id is not None for entry in entries)
+        all_entries_processed = all(entry.observation_id_id is not None for entry in entries)
         context["all_entries_processed"] = all_entries_processed
 
         return context


### PR DESCRIPTION
Fixes a crash in EntryBatchDetailView when a TrtDataEntry record references a missing observation.

Use the raw foreign key value (observation_id_id) when determining whether batch entries have been processed, avoiding unnecessary dereferencing of TrtObservations records.

This allows batches containing orphaned observation references to continue rendering without raising TrtObservations.DoesNotExist.