### PR TITLE
T062 make tag order optional and remove field person and TAG limit

### DIFF
--- a/wamtram2/forms.py
+++ b/wamtram2/forms.py
@@ -779,11 +779,12 @@ class TagRegisterForm(forms.Form):
     tag_prefix = forms.CharField(max_length=5, label="Tag Prefix", required=False)
     start_number = forms.CharField(max_length=15, label="Start Tag Number")
     end_number = forms.CharField(max_length=15, label="End Tag Number")
-    tag_order_id = forms.IntegerField(label="Tag Order ID")
+    tag_order_id = forms.IntegerField(label="Tag Order ID", required=False)
     issue_location = forms.CharField(max_length=50, required=True, label="Issue Location")
     comments = forms.CharField(widget=forms.Textarea, required=False)
 
     custodian_person_id = forms.CharField(widget=forms.HiddenInput(), required=False)
+    # Removed from UI but retained for backwards compatibility.
     field_person_id = forms.CharField(widget=forms.HiddenInput(), required=False)
 
 

--- a/wamtram2/templates/wamtram2/tag_register.html
+++ b/wamtram2/templates/wamtram2/tag_register.html
@@ -111,20 +111,6 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-md-6">
-                        <div class="form-group">
-                            <label for="fieldPerson">Field Person</label>
-                            <div class="search-container">
-                                <input type="text" 
-                                    id="fieldPerson" 
-                                    class="search-field form-control-sm" 
-                                    placeholder="Search for field person..." 
-                                    autocomplete="off">
-                                <input type="hidden" id="fieldPersonId" name="field_person_id">
-                                <div id="fieldSearchResults" class="search-results"></div>
-                            </div>
-                        </div>
-                    </div>
                 </div>
 
                 <!-- Comments -->
@@ -362,7 +348,6 @@
     // Initialize person search
     document.addEventListener('DOMContentLoaded', function() {
         setupPersonSearch('custodianPerson', 'custodianPersonId', 'custodianSearchResults');
-        setupPersonSearch('fieldPerson', 'fieldPersonId', 'fieldSearchResults');
     });
 
     document.addEventListener('DOMContentLoaded', function() {

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -3810,7 +3810,7 @@ class TagRegisterView(LoginRequiredMixin, FormView):
                             issue_location=form.cleaned_data["issue_location"],
                             custodian_person_id=form.cleaned_data["custodian_person_id"],
                             # Retained for backwards compatibility (T062).
-                            field_person_id=form.cleaned_data["field_person_id"],
+                            field_person_id=None,
                             comments=form.cleaned_data["comments"],
                             tag_status=tag_status,
                         )
@@ -3826,7 +3826,7 @@ class TagRegisterView(LoginRequiredMixin, FormView):
                             issue_location=form.cleaned_data["issue_location"],
                             custodian_person_id=form.cleaned_data["custodian_person_id"],
                             # Retained for backwards compatibility (T062).
-                            field_person_id=form.cleaned_data["field_person_id"],
+                            field_person_id=None,
                             comments=form.cleaned_data["comments"],
                             pit_tag_status=pit_tag_status,
                         )

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -3788,10 +3788,9 @@ class TagRegisterView(LoginRequiredMixin, FormView):
             prefix = form.cleaned_data["tag_prefix"]
             start = int(form.cleaned_data["start_number"])
             end = int(form.cleaned_data["end_number"])
-
-            if end - start > 1000:
-                return JsonResponse({"success": False, "error": "Cannot create more than 1000 tags at once"})
-
+            
+            # T062 removed tag registration batch size limit
+            
             with transaction.atomic():
                 for num in range(start, end + 1):
                     if tag_type == "flipper":
@@ -3810,6 +3809,7 @@ class TagRegisterView(LoginRequiredMixin, FormView):
                             tag_order_id=form.cleaned_data["tag_order_id"],
                             issue_location=form.cleaned_data["issue_location"],
                             custodian_person_id=form.cleaned_data["custodian_person_id"],
+                            # Retained for backwards compatibility (T062).
                             field_person_id=form.cleaned_data["field_person_id"],
                             comments=form.cleaned_data["comments"],
                             tag_status=tag_status,
@@ -3825,6 +3825,7 @@ class TagRegisterView(LoginRequiredMixin, FormView):
                             tag_order_id=form.cleaned_data["tag_order_id"],
                             issue_location=form.cleaned_data["issue_location"],
                             custodian_person_id=form.cleaned_data["custodian_person_id"],
+                            # Retained for backwards compatibility (T062).
                             field_person_id=form.cleaned_data["field_person_id"],
                             comments=form.cleaned_data["comments"],
                             pit_tag_status=pit_tag_status,


### PR DESCRIPTION
Tag Registration Improvements

- Made Tag Order ID optional
- Removed Field Person from registration UI
- Retained field_person_id backend/database fields for backwards compatibility
- Removed registration batch size limit
- Applies to both Flipper Tags and PIT Tags
- No database schema changes
