### PR TITLE
T064 Allow Enter key to trigger turtle searches

### DIFF
--- a/wamtram2/static/js/turtle_management.js
+++ b/wamtram2/static/js/turtle_management.js
@@ -638,6 +638,29 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 
+    const searchInputs = document.querySelectorAll(
+    '#turtleIDSearch, #flipperTagSearch, #pitTagSearch, #otherIdentificationSearch'
+    );
+
+    searchInputs.forEach(input => {
+    input.addEventListener('keydown', function(event) {
+        if (event.key !== 'Enter') {
+            return;
+        }
+
+        event.preventDefault();
+
+        let searchType = this.id.replace('Search', '').toLowerCase();
+        searchType = searchTypeMapping[searchType] || searchType;
+        const searchValue = this.value.trim();
+
+        if (searchValue) {
+            handleSearch(searchType, searchValue);
+        }
+    });
+    });
+
+
     if (saveButton) {
         saveButton.addEventListener('click', function() {
             const changes = getFormChanges();


### PR DESCRIPTION
Users can now press Enter to run searches in the Turtle Management search fields instead of clicking the search button.
Updated search fields:

Turtle ID
Flipper Tag
PIT Tag
Other Identification

This provides a quicker and more intuitive search experience.