### PR TITLE
T073 Fix admin user creation page after upgrading to Django 5.2.

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -39,6 +39,21 @@ class UserCreationForm(UserCreationForm):
 class UserAdmin(AuthUserAdmin):
     form = UserChangeForm
     add_form = UserCreationForm
+
+    add_fieldsets = (
+        (
+            None,
+            {
+                "classes": ("wide",),
+                "fields": (
+                    "username",
+                    "password1",
+                    "password2",
+                ),
+            },
+        ),
+    )
+
     fieldsets = (
         (
             "User Profile",


### PR DESCRIPTION
Django 5.2 adds the `usable_password` field to the default
AuthUserAdmin.add_fieldsets. Our custom UserCreationForm does not
support this field, causing:

FieldError: Unknown field(s) (usable_password) specified for User

Override add_fieldsets to restore the previous behaviour and allow
users to be created via Django admin.