### PR TITLE
Release 2.3.4 from develop to main.

### DIFF
--- a/kustomize/overlays/prod/kustomization.yaml
+++ b/kustomize/overlays/prod/kustomization.yaml
@@ -25,4 +25,4 @@ patches:
   - path: service_patch.yaml
 images:
   - name: ghcr.io/dbca-wa/wastd
-    newTag: 2.3.3
+    newTag: 2.3.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wastd"
-version = "2.3.3"
+version = "2.3.4"
 description = "Western Australian Sea Turtles Database"
 authors = [
   { name = "Florian Mayer", email = "florian.mayer@dbca.wa.gov.au" },

--- a/users/admin.py
+++ b/users/admin.py
@@ -39,6 +39,21 @@ class UserCreationForm(UserCreationForm):
 class UserAdmin(AuthUserAdmin):
     form = UserChangeForm
     add_form = UserCreationForm
+
+    add_fieldsets = (
+        (
+            None,
+            {
+                "classes": ("wide",),
+                "fields": (
+                    "username",
+                    "password1",
+                    "password2",
+                ),
+            },
+        ),
+    )
+
     fieldsets = (
         (
             "User Profile",

--- a/wamtram2/forms.py
+++ b/wamtram2/forms.py
@@ -423,7 +423,7 @@ class TrtDataEntryForm(forms.ModelForm):
         self.fields["scars_right_scale_1"].label = "1"
         self.fields["scars_right_scale_2"].label = "2"
         self.fields["scars_right_scale_3"].label = "3"
-        self.fields["tagged_by_id"].label = "Tagged by"
+        self.fields["tagged_by_id"].label = "Tagged by and/or tags read by"
         self.fields["measured_by_id"].label = "Measured by"
         self.fields["tagscarnotchecked"].label = "Didn't check for tag scars"
         self.fields["didnotcheckforinjury"].label = "Didn't check for injury"

--- a/wamtram2/forms.py
+++ b/wamtram2/forms.py
@@ -779,11 +779,12 @@ class TagRegisterForm(forms.Form):
     tag_prefix = forms.CharField(max_length=5, label="Tag Prefix", required=False)
     start_number = forms.CharField(max_length=15, label="Start Tag Number")
     end_number = forms.CharField(max_length=15, label="End Tag Number")
-    tag_order_id = forms.IntegerField(label="Tag Order ID")
+    tag_order_id = forms.IntegerField(label="Tag Order ID", required=False)
     issue_location = forms.CharField(max_length=50, required=True, label="Issue Location")
     comments = forms.CharField(widget=forms.Textarea, required=False)
 
     custodian_person_id = forms.CharField(widget=forms.HiddenInput(), required=False)
+    # Removed from UI but retained for backwards compatibility.
     field_person_id = forms.CharField(widget=forms.HiddenInput(), required=False)
 
 

--- a/wamtram2/static/js/turtle_management.js
+++ b/wamtram2/static/js/turtle_management.js
@@ -638,6 +638,29 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 
+    const searchInputs = document.querySelectorAll(
+    '#turtleIDSearch, #flipperTagSearch, #pitTagSearch, #otherIdentificationSearch'
+    );
+
+    searchInputs.forEach(input => {
+    input.addEventListener('keydown', function(event) {
+        if (event.key !== 'Enter') {
+            return;
+        }
+
+        event.preventDefault();
+
+        let searchType = this.id.replace('Search', '').toLowerCase();
+        searchType = searchTypeMapping[searchType] || searchType;
+        const searchValue = this.value.trim();
+
+        if (searchValue) {
+            handleSearch(searchType, searchValue);
+        }
+    });
+    });
+
+
     if (saveButton) {
         saveButton.addEventListener('click', function() {
             const changes = getFormChanges();

--- a/wamtram2/templates/wamtram2/tag_register.html
+++ b/wamtram2/templates/wamtram2/tag_register.html
@@ -111,20 +111,6 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-md-6">
-                        <div class="form-group">
-                            <label for="fieldPerson">Field Person</label>
-                            <div class="search-container">
-                                <input type="text" 
-                                    id="fieldPerson" 
-                                    class="search-field form-control-sm" 
-                                    placeholder="Search for field person..." 
-                                    autocomplete="off">
-                                <input type="hidden" id="fieldPersonId" name="field_person_id">
-                                <div id="fieldSearchResults" class="search-results"></div>
-                            </div>
-                        </div>
-                    </div>
                 </div>
 
                 <!-- Comments -->
@@ -362,7 +348,6 @@
     // Initialize person search
     document.addEventListener('DOMContentLoaded', function() {
         setupPersonSearch('custodianPerson', 'custodianPersonId', 'custodianSearchResults');
-        setupPersonSearch('fieldPerson', 'fieldPersonId', 'fieldSearchResults');
     });
 
     document.addEventListener('DOMContentLoaded', function() {

--- a/wamtram2/templates/wamtram2/tag_register.html
+++ b/wamtram2/templates/wamtram2/tag_register.html
@@ -72,7 +72,7 @@
                     <div class="col-md-3">
                         <div class="form-group">
                             <label for="tagOrderId">Tag Order ID</label>
-                            <input type="number" class="form-control form-control-sm" id="tagOrderId" name="tag_order_id" required>
+                            <input type="number" class="form-control form-control-sm" id="tagOrderId" name="tag_order_id" >
                         </div>
                     </div>
                 </div>

--- a/wamtram2/templates/wamtram2/trtdataentry_form.html
+++ b/wamtram2/templates/wamtram2/trtdataentry_form.html
@@ -274,17 +274,7 @@
         </div>
       </div>
       {% endif %}
-      <!-- Tagged By Section -->
-      <section class="container-fluid mt-5">
-        <div class="col-md-12">
-          <label for="{{ form.tagged_by_id.id_for_label }}">{{ form.tagged_by_id.label }}</label>
-        </div>
-        <div class="col-md-4">
-          <input type="text" id="search_tagged_by" class="search-field form-control" placeholder="Search tagged by" value="{{ tagged_by_name }}">
-          {{ form.tagged_by_id }}
-          <div class="search-results" style="display:none;"></div>
-        </div>
-      </section>
+
       <!-- Flipper Tags Section -->
       <section class="container-fluid mt-5">
           <div class="row">
@@ -304,24 +294,25 @@
           <!-- Table for Flipper Tags -->
           <table class="table table-borderless" id="oldFlipperTagSection">
             <thead>
-              <tr>
-                <th></th>
-                <th style="width: 40%;">Tag Number</th>
-                <th>Tag State</th>
-                <th>Tag Position</th>
-                <th>Barnacles?</th>
-              </tr>
-            </thead>
-            <tbody>
               <!-- Old Flipper Tag -->
               <tr>
                 <td colspan="4">
                   <h5><span style="color: blue; font-weight: bold">OLD</span> Flipper Tag(s)</h5>
                 </td>
               </tr>
+              <tr>
+                <th></th>
+                <th style="width: 40%;">OLD Tag Number</th>
+                <th>Tag State</th>
+                <th>Tag Position</th>
+                <th>Barnacles?</th>
+              </tr>
+            </thead>
+            <tbody>
+              
               <!-- Old Left Flipper Tag -->
               <tr>
-                <td><strong>L1</strong></td>
+                <td><strong>LEFT</strong></td>
                 <td>
                   {% bootstrap_field form.recapture_left_tag_id show_label=False %}
                   <span id="left-tag-validation-message"></span>
@@ -333,7 +324,7 @@
               </tr>
               <!-- Old Right Flipper Tag -->
               <tr>
-                <td><strong>R1</strong></td>
+                <td><strong>RIGHT</strong></td>
                 <td>
                   {% bootstrap_field form.recapture_right_tag_id show_label=False %}
                   <span id="right-tag-validation-message"></span>
@@ -345,7 +336,7 @@
               </tr>
               <!-- Additional Old Left Flipper Tag -->
               <tr id="additionalRecaptureLeftTag" style="display: none;">
-                <td><strong>L2</strong></td>
+                <td><strong>LEFT2</strong></td>
                 <td>
                   {% bootstrap_field form.recapture_left_tag_id_2 show_label=False %}
                   <span id="left-tag-validation-message-2"></span>
@@ -357,7 +348,7 @@
               </tr>
               <!-- Additional Old Right Flipper Tag -->
               <tr id="additionalRecaptureRightTag" style="display: none;">
-                <td><strong>R2</strong></td>
+                <td><strong>RIGHT2</strong></td>
                 <td>
                   {% bootstrap_field form.recapture_right_tag_id_2 show_label=False %}
                   <span id="right-tag-validation-message-2"></span>
@@ -428,9 +419,15 @@
           <!-- New Flipper Tag Section -->
           <table class="table table-borderless mt-5" id="newFlipperTagSection">
             <thead>
+              <!-- New Flipper Tag -->
+              <tr>
+                <td colspan="4">
+                  <h5><span style="color: red; font-weight: bold">NEW</span> Flipper Tag(s)</h5>
+                </td>
+              </tr>
               <tr>
                 <th></th>
-                <th style="width: 50%;">Tag Number</th>
+                <th style="width: 50%;">NEW Tag Number</th>
                 <th>Tag State</th>
                 <th>Tag Position</th>
                 <th>         </th>
@@ -438,15 +435,9 @@
               </tr>
             </thead>
             <tbody>
-              <!-- New Flipper Tag -->
-              <tr>
-                <td colspan="4">
-                  <h5><span style="color: red; font-weight: bold">NEW</span> Flipper Tag(s)</h5>
-                </td>
-              </tr>
               <!-- New Left Flipper Tag -->
               <tr>
-                <td><strong>L1</strong></td>
+                <td><strong>LEFT</strong></td>
                 <td>
                   {% bootstrap_field form.new_left_tag_id show_label=False %}
                   <span id="new-left-tag-validation-message"></span>
@@ -457,7 +448,7 @@
               </tr>
               <!-- New Right Flipper Tag -->
               <tr>
-                <td><strong>R1</strong></td>
+                <td><strong>RIGHT</strong></td>
                 <td>
                   {% bootstrap_field form.new_right_tag_id show_label=False %}
                   <span id="new-right-tag-validation-message"></span>
@@ -469,7 +460,7 @@
               </tr>
               <!-- Additional New Left Flipper Tag -->
               <tr id="additionalNewLeftTag" style="display: none;">
-                <td><strong>L2</strong></td>
+                <td><strong>LEFT2</strong></td>
                 <td>
                   {% bootstrap_field form.new_left_tag_id_2 show_label=False %}
                   <span id="new-left-tag-validation-message-2"></span>
@@ -480,7 +471,7 @@
               </tr>
               <!-- Additional New Right Flipper Tag -->
               <tr id="additionalNewRightTag" style="display: none;">
-                <td><strong>R2</strong></td>
+                <td><strong>RIGHT2</strong></td>
                 <td>
                   {% bootstrap_field form.new_right_tag_id_2 show_label=False %}
                   <span id="new-right-tag-validation-message-2"></span>
@@ -507,6 +498,27 @@
 
       </section> {% endcomment %}
 
+      <!-- Tagged By Section -->
+      <section class="container-fluid mt-5">
+        <div class="col-md-12">
+          <label for="{{ form.tagged_by_id.id_for_label }}">
+            {{ form.tagged_by_id.label }}
+          </label>
+        </div>
+
+        <div class="col-md-4">
+          <input
+            type="text"
+            id="search_tagged_by"
+            class="search-field form-control"
+            placeholder="Search tagged by and/or tags read by"
+            value="{{ tagged_by_name }}"
+          >
+          {{ form.tagged_by_id }}
+          <div class="search-results" style="display:none;"></div>
+        </div>
+      </section>
+      <hr class="my-5">
       <!-- PIT Tags Section -->
       <section class="container-fluid mt-5">
         <div class="col-md-12">
@@ -526,7 +538,7 @@
               <div class="col-md-6">
                 <div class="row">
                   <div class="col-md-2 d-flex align-items-center">
-                    <strong>L1</strong>
+                    <strong>LEFT</strong>
                   </div>
                   <div class="col-md-10 mt-4">
                     {% bootstrap_field form.recapture_pittag_id show_label=False %}
@@ -538,7 +550,7 @@
               <div class="col-md-6">
                 <div class="row">
                   <div class="col-md-2 d-flex align-items-center">
-                    <strong>R1</strong>
+                    <strong>RIGHT</strong>
                   </div>
                   <div class="col-md-10 mt-4">
                     {% bootstrap_field form.recapture_pittag_id_2 show_label=False %}
@@ -554,7 +566,7 @@
                 <div class="col-md-6">
                   <div class="row">
                     <div class="col-md-2 d-flex align-items-center">
-                      <strong>L2</strong>
+                      <strong>LEFT2</strong>
                     </div>
                     <div class="col-md-10 mt-4">
                       {% bootstrap_field form.recapture_pittag_id_3 show_label=False %}
@@ -566,7 +578,7 @@
                 <div class="col-md-6">
                   <div class="row">
                     <div class="col-md-2 d-flex align-items-center">
-                      <strong>R2</strong>
+                      <strong>RIGHT2</strong>
                     </div>
                     <div class="col-md-10 mt-4">
                       {% bootstrap_field form.recapture_pittag_id_4 show_label=False %}
@@ -592,7 +604,7 @@
               <div class="col-md-6">
                 <div class="row">
                   <div class="col-md-2 d-flex align-items-center">
-                    <strong>L1</strong>
+                    <strong>LEFT</strong>
                   </div>
                   <div class="col-md-7 mt-4">
                     {% bootstrap_field form.new_pittag_id show_label=False %}
@@ -609,7 +621,7 @@
               <div class="col-md-6">
                 <div class="row">
                   <div class="col-md-2 d-flex align-items-center">
-                    <strong>R1</strong>
+                    <strong>RIGHT</strong>
                   </div>
                   <div class="col-md-7 mt-4">
                     {% bootstrap_field form.new_pittag_id_2 show_label=False %}
@@ -629,7 +641,7 @@
                 <div class="col-md-6">
                   <div class="row">
                     <div class="col-md-2 d-flex align-items-center">
-                      <strong>L2</strong>
+                      <strong>LEFT2</strong>
                     </div>
                     <div class="col-md-7 mt-4">
                       {% bootstrap_field form.new_pittag_id_3 show_label=False %}
@@ -646,7 +658,7 @@
                 <div class="col-md-6">
                   <div class="row">
                     <div class="col-md-2 d-flex align-items-center">
-                      <strong>R2</strong>
+                      <strong>RIGHT2</strong>
                     </div>
                     <div class="col-md-7 mt-4">
                       {% bootstrap_field form.new_pittag_id_4 show_label=False %}

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -255,7 +255,7 @@ class EntryBatchDetailView(LoginRequiredMixin, FormMixin, ListView):
         )
 
         entries = TrtDataEntry.objects.filter(entry_batch_id=batch.entry_batch_id)
-        all_entries_processed = all(entry.observation_id is not None for entry in entries)
+        all_entries_processed = all(entry.observation_id_id is not None for entry in entries)
         context["all_entries_processed"] = all_entries_processed
 
         return context

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -3810,7 +3810,7 @@ class TagRegisterView(LoginRequiredMixin, FormView):
                             issue_location=form.cleaned_data["issue_location"],
                             custodian_person_id=form.cleaned_data["custodian_person_id"],
                             # Retained for backwards compatibility (T062).
-                            field_person_id=form.cleaned_data["field_person_id"],
+                            field_person_id=None,
                             comments=form.cleaned_data["comments"],
                             tag_status=tag_status,
                         )
@@ -3826,7 +3826,7 @@ class TagRegisterView(LoginRequiredMixin, FormView):
                             issue_location=form.cleaned_data["issue_location"],
                             custodian_person_id=form.cleaned_data["custodian_person_id"],
                             # Retained for backwards compatibility (T062).
-                            field_person_id=form.cleaned_data["field_person_id"],
+                            field_person_id=None,
                             comments=form.cleaned_data["comments"],
                             pit_tag_status=pit_tag_status,
                         )

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -3788,10 +3788,9 @@ class TagRegisterView(LoginRequiredMixin, FormView):
             prefix = form.cleaned_data["tag_prefix"]
             start = int(form.cleaned_data["start_number"])
             end = int(form.cleaned_data["end_number"])
-
-            if end - start > 1000:
-                return JsonResponse({"success": False, "error": "Cannot create more than 1000 tags at once"})
-
+            
+            # T062 removed tag registration batch size limit
+            
             with transaction.atomic():
                 for num in range(start, end + 1):
                     if tag_type == "flipper":
@@ -3810,6 +3809,7 @@ class TagRegisterView(LoginRequiredMixin, FormView):
                             tag_order_id=form.cleaned_data["tag_order_id"],
                             issue_location=form.cleaned_data["issue_location"],
                             custodian_person_id=form.cleaned_data["custodian_person_id"],
+                            # Retained for backwards compatibility (T062).
                             field_person_id=form.cleaned_data["field_person_id"],
                             comments=form.cleaned_data["comments"],
                             tag_status=tag_status,
@@ -3825,6 +3825,7 @@ class TagRegisterView(LoginRequiredMixin, FormView):
                             tag_order_id=form.cleaned_data["tag_order_id"],
                             issue_location=form.cleaned_data["issue_location"],
                             custodian_person_id=form.cleaned_data["custodian_person_id"],
+                            # Retained for backwards compatibility (T062).
                             field_person_id=form.cleaned_data["field_person_id"],
                             comments=form.cleaned_data["comments"],
                             pit_tag_status=pit_tag_status,


### PR DESCRIPTION
## Summary

Release 2.3.4 from develop to main.

## Included Changes

- Fix admin user creation page after upgrading to Django 5.2.
- Update flipper tag tables and tagged-by placement.
- Allow Enter key to trigger turtle searches.
- Make tag order ID optional in the UI.
- Make tag order optional and remove field person and TAG limits.

## Version

- Bump production version from 2.3.3 to 2.3.4.