### PR TITLE
T016: show interrupted by nesting team field in observation details

### DIFF
--- a/wamtram2/static/js/turtle_management.js
+++ b/wamtram2/static/js/turtle_management.js
@@ -421,6 +421,16 @@ document.addEventListener('DOMContentLoaded', function() {
                                     <input type="text" class="form-control" name="activity" value="${obs.activity || ''}"  readonly>
                                 </div>
                             </div>
+                            <div class="col-md-2">
+                                <div class="form-group">
+                                    <label>Interrupted by nesting team</label>
+                                    <input type="text"
+                                        class="form-control"
+                                        name="interrupted"
+                                        value="${obs.interrupted || ''}"
+                                        readonly>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/wamtram2/static/js/turtle_management.js
+++ b/wamtram2/static/js/turtle_management.js
@@ -403,13 +403,13 @@ document.addEventListener('DOMContentLoaded', function() {
                                     <input type="text" class="form-control" name="observation_status" value="${obs.observation_status || ''}"  readonly>
                                 </div>
                             </div>
-                            <div class="col-md-2">
+                            <div class="col-md-1">
                                 <div class="form-group">
                                     <label>Alive</label>
                                     <input type="text" class="form-control" name="alive" value="${obs.alive || ''}"  readonly>
                                 </div>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-2">
                                 <div class="form-group">
                                     <label>Place</label>
                                     <input type="text" class="form-control" name="place" value="${obs.place || ''}"  readonly>

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -5586,11 +5586,6 @@ class TurtleManagementView(LoginRequiredMixin, SuperUserRequiredMixin, TemplateV
                     .filter(observation_id=obs)
                     .first()
                 )
-                print(
-                    f"obs={obs.pk}, "
-                    f"entry={entry.data_entry_id if entry else None}, "
-                    f"interrupted={entry.interrupted if entry else None}"
-                    )
 
                 observation_data.append({
                     "observation_id": obs.pk,

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -5577,8 +5577,34 @@ class TurtleManagementView(LoginRequiredMixin, SuperUserRequiredMixin, TemplateV
             ]
 
             observations = turtle.trtobservations_set.select_related("place_code", "activity_code").all()
-            observation_data = [
-                {
+            # observation_data = [
+            #     {
+            #         "observation_id": obs.pk,
+            #         "date_time": obs.observation_date.strftime("%Y-%m-%dT%H:%M"),
+            #         "observation_status": obs.observation_status,
+            #         "alive": str(obs.alive),
+            #         "place": obs.place_code.get_full_name() if obs.place_code else "",
+            #         "nesting": str(obs.nesting),
+            #         "activity": str(obs.activity_code),
+            #     }
+            #     for obs in observations
+            # ]
+            observation_data = []
+
+            for obs in observations:
+                entry = (
+                    TrtDataEntry.objects
+                    .select_related("interrupted")
+                    .filter(observation_id=obs)
+                    .first()
+                )
+                print(
+                    f"obs={obs.pk}, "
+                    f"entry={entry.data_entry_id if entry else None}, "
+                    f"interrupted={entry.interrupted if entry else None}"
+                    )
+
+                observation_data.append({
                     "observation_id": obs.pk,
                     "date_time": obs.observation_date.strftime("%Y-%m-%dT%H:%M"),
                     "observation_status": obs.observation_status,
@@ -5586,9 +5612,8 @@ class TurtleManagementView(LoginRequiredMixin, SuperUserRequiredMixin, TemplateV
                     "place": obs.place_code.get_full_name() if obs.place_code else "",
                     "nesting": str(obs.nesting),
                     "activity": str(obs.activity_code),
-                }
-                for obs in observations
-            ]
+                    "interrupted": str(entry.interrupted) if entry and entry.interrupted else "",
+                })
 
             samples = turtle.trtsamples_set.all()
             sample_data = [

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -5577,18 +5577,6 @@ class TurtleManagementView(LoginRequiredMixin, SuperUserRequiredMixin, TemplateV
             ]
 
             observations = turtle.trtobservations_set.select_related("place_code", "activity_code").all()
-            # observation_data = [
-            #     {
-            #         "observation_id": obs.pk,
-            #         "date_time": obs.observation_date.strftime("%Y-%m-%dT%H:%M"),
-            #         "observation_status": obs.observation_status,
-            #         "alive": str(obs.alive),
-            #         "place": obs.place_code.get_full_name() if obs.place_code else "",
-            #         "nesting": str(obs.nesting),
-            #         "activity": str(obs.activity_code),
-            #     }
-            #     for obs in observations
-            # ]
             observation_data = []
 
             for obs in observations:


### PR DESCRIPTION
## Summary

Adds the "Was nesting interrupted by tagging team?" field to the Turtle Management observation display.

This information exists in TRT Data Entry records but was not previously shown in the Curation Tools > Data Management > Turtle Management observations section.

## Changes
- Retrieve the associated `TrtDataEntry` record for each observation.
- Include the `interrupted` value in the turtle search API response.
- Add a read-only "Was nesting interrupted by tagging team?" field to the Observation card in Turtle Management.
- Display the value returned by the API.

## Testing

Verified that:
- The turtle search API returns the `interrupted` field.
- Existing observation details continue to display correctly.
- Observation records display the expected interrupted value (e.g. "Yes", "No", "Partial" where applicable).
- No regressions observed in Turtle Management search results.

## Notes

"Did the turtle lay?" is already represented in the existing observation information and does not require additional changes.