### PR TITLE
T031 Add Samples tab to Observation Management

### DIFF
--- a/wamtram2/static/js/observation_management.js
+++ b/wamtram2/static/js/observation_management.js
@@ -422,6 +422,7 @@ function setInitialFormValues() {
         setDamageRecords();
         setIdentification();
         setScars();
+        setSamples();
         saveOriginalFormData();
         
         // Then initialize change tracking after all values are set
@@ -429,6 +430,31 @@ function setInitialFormValues() {
             initializeChangeTracking();
         }, 100);
     }
+}
+
+function setSamples() {
+    const container = document.getElementById('sampleContainer');
+
+    if (!container || !initialData.samples) return;
+
+    if (initialData.samples.length === 0) {
+        container.innerHTML = '<p class="text-muted">No samples found</p>';
+        return;
+    }
+
+    container.innerHTML = '';
+
+    initialData.samples.forEach(sample => {
+        container.insertAdjacentHTML('beforeend', `
+            <div class="card mb-3">
+                <div class="card-body">
+                    <p><strong>Tissue Type:</strong> ${sample.tissue_type || ''}</p>
+                    <p><strong>Sample Label:</strong> ${sample.sample_label || ''}</p>
+                    <p><strong>Comments:</strong> ${sample.comments || ''}</p>
+                </div>
+            </div>
+        `);
+    });
 }
 
 // Set basic form fields

--- a/wamtram2/static/js/observation_management.js
+++ b/wamtram2/static/js/observation_management.js
@@ -432,25 +432,6 @@ function setInitialFormValues() {
     }
 }
 
-function setSamples() {
-    const sampleContainer = document.getElementById('sampleContainer');
-    if (!sampleContainer || !initialData.samples) return;
-
-    sampleContainer.innerHTML = '';
-
-    if (initialData.samples.length === 0) {
-        sampleContainer.innerHTML =
-            '<p class="text-muted">No samples found</p>';
-        return;
-    }
-
-    initialData.samples.forEach(sample => {
-        sampleContainer.insertAdjacentHTML(
-            'beforeend',
-            generateSampleHtml(sample)
-        );
-    });
-}
 
 // Set basic form fields
 function setBasicFields() {
@@ -964,6 +945,9 @@ function setSamples() {
 }
 
 function generateSampleHtml(sample = {}) {
+    const tissueTypes = JSON.parse(
+        document.getElementById('tissue-types-data').textContent
+    );
     return `
         <div class="sample-row card mb-3"
              data-sample-id="${sample.sample_id || ''}">
@@ -971,10 +955,17 @@ function generateSampleHtml(sample = {}) {
                 <div class="form-row">
                     <div class="col-md-3">
                         <label>Tissue Type</label>
-                        <input type="text"
-                               class="form-control"
-                               name="tissue_type"
-                               value="${sample.tissue_type || ''}">
+                        <select class="form-control" name="tissue_type">
+                            ${tissueTypes.map(type => `
+                                <option
+                                    value="${type.tissue_type}"
+                                    ${String(sample.tissue_type || '') === String(type.tissue_type)
+                                        ? 'selected'
+                                        : ''}>
+                                    ${type.description}
+                                </option>
+                            `).join('')}
+                        </select>
                     </div>
 
                     <div class="col-md-3">
@@ -1632,35 +1623,114 @@ document.addEventListener('DOMContentLoaded', function() {
         if (saveDamageBtn) {
             saveDamageBtn.addEventListener('click', saveDamageChanges);
         }
+        // Samples buttons
         const addSampleBtn = document.getElementById('addSampleBtn');
 
         if (addSampleBtn) {
-            addSampleBtn.addEventListener('click', function () {
-                const sampleContainer = document.getElementById('sampleContainer');
-
-                if (
-                    sampleContainer.innerHTML.includes('No samples found')
-                ) {
-                    sampleContainer.innerHTML = '';
-                }
-
-                sampleContainer.insertAdjacentHTML(
-                    'beforeend',
-                    generateSampleHtml()
-                );
-            });
+            addSampleBtn.addEventListener('click', addSample);
         }
+
         const sampleContainer = document.getElementById('sampleContainer');
 
         if (sampleContainer) {
             sampleContainer.addEventListener('click', function(e) {
                 if (e.target.closest('.delete-sample')) {
-                    e.target.closest('.sample-row').remove();
+                    deleteSample(e);
                 }
             });
         }
+
+        const saveSamplesBtn = document.getElementById('saveSamplesBtn');
+
+        if (saveSamplesBtn) {
+            saveSamplesBtn.addEventListener('click', saveSampleChanges);
+        }
 });
 
+// Samples
+let deletedSamples = new Set();
+
+function addSample() {
+    const sampleContainer = document.getElementById('sampleContainer');
+
+    if (sampleContainer.innerHTML.includes('No samples found')) {
+        sampleContainer.innerHTML = '';
+    }
+
+    sampleContainer.insertAdjacentHTML(
+        'beforeend',
+        generateSampleHtml()
+    );
+}
+
+function deleteSample(event) {
+    const sampleCard = event.target.closest('.sample-row');
+
+    if (!sampleCard) return;
+
+    const sampleId = sampleCard.dataset.sampleId;
+
+    if (sampleCard.classList.contains('deleted')) {
+        sampleCard.classList.remove('deleted');
+        deletedSamples.delete(sampleId);
+    } else {
+        sampleCard.classList.add('deleted');
+
+        if (sampleId) {
+            deletedSamples.add(sampleId);
+        }
+    }
+
+    sampleCard.remove();
+}
+
+async function saveSampleChanges() {
+    const samples = [];
+
+    document
+        .querySelectorAll('.sample-row:not(.deleted)')
+        .forEach(card => {
+            samples.push({
+                sample_id: card.dataset.sampleId || null,
+                tissue_type: card.querySelector('[name="tissue_type"]').value,
+                sample_label: card.querySelector('[name="sample_label"]').value,
+                comments: card.querySelector('[name="comments"]').value,
+                observation_id: initialData.basic_info.observation_id
+            });
+        });
+
+    try {
+        const csrfToken =
+            document.querySelector('[name=csrfmiddlewaretoken]').value;
+
+        const response = await fetch(
+            '/wamtram2/api/samples-update/',
+            {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': csrfToken
+                },
+                body: JSON.stringify({
+                    turtle_id: initialData.basic_info.turtle_id,
+                    samples: samples,
+                    deletedSamples: Array.from(deletedSamples)
+                })
+            }
+        );
+
+        const data = await response.json();
+
+        if (data.status === 'success') {
+            alert('Samples updated successfully!');
+            location.reload();
+        } else {
+            alert(`Error: ${data.message}`);
+        }
+    } catch (error) {
+        alert(`Save failed: ${error.message}`);
+    }
+}
 // Add global variable to track deleted measurements
 let deletedMeasurements = new Set();
 
@@ -1836,6 +1906,7 @@ async function saveMeasurementChanges() {
         alert(`Save failed: ${error.message}`);
     }
 }
+
 
 // Add global variable to track deleted damage records
 let deletedDamage = new Set();

--- a/wamtram2/static/js/observation_management.js
+++ b/wamtram2/static/js/observation_management.js
@@ -433,27 +433,22 @@ function setInitialFormValues() {
 }
 
 function setSamples() {
-    const container = document.getElementById('sampleContainer');
+    const sampleContainer = document.getElementById('sampleContainer');
+    if (!sampleContainer || !initialData.samples) return;
 
-    if (!container || !initialData.samples) return;
+    sampleContainer.innerHTML = '';
 
     if (initialData.samples.length === 0) {
-        container.innerHTML = '<p class="text-muted">No samples found</p>';
+        sampleContainer.innerHTML =
+            '<p class="text-muted">No samples found</p>';
         return;
     }
 
-    container.innerHTML = '';
-
     initialData.samples.forEach(sample => {
-        container.insertAdjacentHTML('beforeend', `
-            <div class="card mb-3">
-                <div class="card-body">
-                    <p><strong>Tissue Type:</strong> ${sample.tissue_type || ''}</p>
-                    <p><strong>Sample Label:</strong> ${sample.sample_label || ''}</p>
-                    <p><strong>Comments:</strong> ${sample.comments || ''}</p>
-                </div>
-            </div>
-        `);
+        sampleContainer.insertAdjacentHTML(
+            'beforeend',
+            generateSampleHtml(sample)
+        );
     });
 }
 
@@ -947,7 +942,69 @@ function setScars() {
         `;
         container.innerHTML = scarsHtml;
 }
-    
+// Set samples data  
+function setSamples() {
+    const sampleContainer = document.getElementById('sampleContainer');
+    if (!sampleContainer || !initialData.samples) return;
+
+    sampleContainer.innerHTML = '';
+
+    if (initialData.samples.length === 0) {
+        sampleContainer.innerHTML =
+            '<p class="text-muted">No samples found</p>';
+        return;
+    }
+
+    initialData.samples.forEach(sample => {
+        sampleContainer.insertAdjacentHTML(
+            'beforeend',
+            generateSampleHtml(sample)
+        );
+    });
+}
+
+function generateSampleHtml(sample = {}) {
+    return `
+        <div class="sample-row card mb-3"
+             data-sample-id="${sample.sample_id || ''}">
+            <div class="card-body">
+                <div class="form-row">
+                    <div class="col-md-3">
+                        <label>Tissue Type</label>
+                        <input type="text"
+                               class="form-control"
+                               name="tissue_type"
+                               value="${sample.tissue_type || ''}">
+                    </div>
+
+                    <div class="col-md-3">
+                        <label>Sample Label</label>
+                        <input type="text"
+                               class="form-control"
+                               name="sample_label"
+                               value="${sample.sample_label || ''}">
+                    </div>
+
+                    <div class="col-md-5">
+                        <label>Comments</label>
+                        <input type="text"
+                               class="form-control"
+                               name="comments"
+                               value="${sample.comments || ''}">
+                    </div>
+
+                    <div class="col-md-1">
+                        <label>&nbsp;</label>
+                        <button type="button"
+                                class="btn btn-danger btn-block delete-sample">
+                            <i class="fas fa-trash"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
+}
 
 function saveOriginalFormData() {
     originalFormData = {};
@@ -1574,6 +1631,33 @@ document.addEventListener('DOMContentLoaded', function() {
         const saveDamageBtn = document.getElementById('saveDamageBtn');
         if (saveDamageBtn) {
             saveDamageBtn.addEventListener('click', saveDamageChanges);
+        }
+        const addSampleBtn = document.getElementById('addSampleBtn');
+
+        if (addSampleBtn) {
+            addSampleBtn.addEventListener('click', function () {
+                const sampleContainer = document.getElementById('sampleContainer');
+
+                if (
+                    sampleContainer.innerHTML.includes('No samples found')
+                ) {
+                    sampleContainer.innerHTML = '';
+                }
+
+                sampleContainer.insertAdjacentHTML(
+                    'beforeend',
+                    generateSampleHtml()
+                );
+            });
+        }
+        const sampleContainer = document.getElementById('sampleContainer');
+
+        if (sampleContainer) {
+            sampleContainer.addEventListener('click', function(e) {
+                if (e.target.closest('.delete-sample')) {
+                    e.target.closest('.sample-row').remove();
+                }
+            });
         }
 });
 

--- a/wamtram2/static/js/turtle_management.js
+++ b/wamtram2/static/js/turtle_management.js
@@ -1053,7 +1053,7 @@ document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('sampleContainer');
         const clone = template.content.cloneNode(true);
         
-        // 填充组织类型下拉框
+        
         const tissueTypeSelect = clone.querySelector('[name="tissue_type"]');
         const tissueTypes = JSON.parse(document.getElementById('tissue-types-data').textContent);
         tissueTypes.forEach(type => {
@@ -1063,7 +1063,6 @@ document.addEventListener('DOMContentLoaded', function() {
             tissueTypeSelect.appendChild(option);
         });
         
-        // 添加删除按钮事件监听器
         clone.querySelector('.delete-sample').addEventListener('click', function() {
             this.closest('.sample-card').remove();
         });
@@ -1232,11 +1231,6 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         }
     });
-
-    // Load tissue types
-    function loadTissueTypes() {
-        return JSON.parse(document.getElementById('tissue-types-data').textContent);
-    }
 
     // Load document types
     function loadDocumentTypes() {

--- a/wamtram2/static/js/turtle_management.js
+++ b/wamtram2/static/js/turtle_management.js
@@ -421,6 +421,16 @@ document.addEventListener('DOMContentLoaded', function() {
                                     <input type="text" class="form-control" name="activity" value="${obs.activity || ''}"  readonly>
                                 </div>
                             </div>
+                            <div class="col-md-2">
+                                <div class="form-group">
+                                    <label>Interrupted by nesting team</label>
+                                    <input type="text"
+                                        class="form-control"
+                                        name="interrupted"
+                                        value="${obs.interrupted || ''}"
+                                        readonly>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/wamtram2/static/js/turtle_management.js
+++ b/wamtram2/static/js/turtle_management.js
@@ -403,13 +403,13 @@ document.addEventListener('DOMContentLoaded', function() {
                                     <input type="text" class="form-control" name="observation_status" value="${obs.observation_status || ''}"  readonly>
                                 </div>
                             </div>
-                            <div class="col-md-2">
+                            <div class="col-md-1">
                                 <div class="form-group">
                                     <label>Alive</label>
                                     <input type="text" class="form-control" name="alive" value="${obs.alive || ''}"  readonly>
                                 </div>
                             </div>
-                            <div class="col-md-3">
+                            <div class="col-md-2">
                                 <div class="form-group">
                                     <label>Place</label>
                                     <input type="text" class="form-control" name="place" value="${obs.place || ''}"  readonly>

--- a/wamtram2/templates/wamtram2/observation_management.html
+++ b/wamtram2/templates/wamtram2/observation_management.html
@@ -481,7 +481,7 @@
         {% else %}
             const initialData = null;
         {% endif %}
-
+        
         const tagStateChoices = {{ tag_states_choices|safe }};
         const pitTagStateChoices = {{ pit_tag_state_choices|safe }};
         const measurementTypeChoices = {{ measurement_type_choices|safe }};
@@ -493,5 +493,6 @@
 
         const turtleDetailUrlTemplate = "{% url 'wamtram2:turtle_detail' 0 %}".replace('/0/', '/'); 
     </script>
+    {{ tissue_types|json_script:"tissue-types-data" }}
     <script src="{% static 'js/observation_management.js' %}"></script>
 {% endblock %} 

--- a/wamtram2/templates/wamtram2/observation_management.html
+++ b/wamtram2/templates/wamtram2/observation_management.html
@@ -320,6 +320,9 @@
         <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#scars">Scars</a>
         </li>
+        <li class="nav-item">
+            <a class="nav-link" data-toggle="tab" href="#samples">Samples</a>
+        </li>
         <!-- Causeomment out Other Information tab 
         <li class="nav-item">
             <a class="nav-link" data-toggle="tab" href="#otherInfo">Other Information</a>
@@ -420,6 +423,23 @@
                 <h4>Scars</h4>
                 <div id="scarsContainer"></div>
                 <button type="button" class="btn btn-success mt-3" onclick="saveScarsChanges()">
+                    <i class="fas fa-save"></i> Save Changes
+                </button>
+            </div>
+        </div>
+        <div id="samples" class="tab-pane fade">
+            <div class="section-card">
+                <h4>Samples</h4>
+
+                <div id="sampleContainer">
+                    <!-- Existing samples will be loaded here -->
+                </div>
+
+                <button type="button" class="btn btn-primary mt-3" id="addSampleBtn">
+                    <i class="fas fa-plus"></i> Add Sample
+                </button>
+
+                <button type="button" class="btn btn-success mt-3" id="saveSamplesBtn">
                     <i class="fas fa-save"></i> Save Changes
                 </button>
             </div>

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -5577,8 +5577,34 @@ class TurtleManagementView(LoginRequiredMixin, SuperUserRequiredMixin, TemplateV
             ]
 
             observations = turtle.trtobservations_set.select_related("place_code", "activity_code").all()
-            observation_data = [
-                {
+            # observation_data = [
+            #     {
+            #         "observation_id": obs.pk,
+            #         "date_time": obs.observation_date.strftime("%Y-%m-%dT%H:%M"),
+            #         "observation_status": obs.observation_status,
+            #         "alive": str(obs.alive),
+            #         "place": obs.place_code.get_full_name() if obs.place_code else "",
+            #         "nesting": str(obs.nesting),
+            #         "activity": str(obs.activity_code),
+            #     }
+            #     for obs in observations
+            # ]
+            observation_data = []
+
+            for obs in observations:
+                entry = (
+                    TrtDataEntry.objects
+                    .select_related("interrupted")
+                    .filter(observation_id=obs)
+                    .first()
+                )
+                print(
+                    f"obs={obs.pk}, "
+                    f"entry={entry.data_entry_id if entry else None}, "
+                    f"interrupted={entry.interrupted if entry else None}"
+                    )
+
+                observation_data.append({
                     "observation_id": obs.pk,
                     "date_time": obs.observation_date.strftime("%Y-%m-%dT%H:%M"),
                     "observation_status": obs.observation_status,
@@ -5586,9 +5612,8 @@ class TurtleManagementView(LoginRequiredMixin, SuperUserRequiredMixin, TemplateV
                     "place": obs.place_code.get_full_name() if obs.place_code else "",
                     "nesting": str(obs.nesting),
                     "activity": str(obs.activity_code),
-                }
-                for obs in observations
-            ]
+                    "interrupted": str(entry.interrupted) if entry and entry.interrupted else "",
+                })
 
             samples = turtle.trtsamples_set.all()
             sample_data = [

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -4892,10 +4892,6 @@ class ObservationDataView(LoginRequiredMixin, SuperUserRequiredMixin, View):
             }
             for measurement in observation.trtmeasurements_set.all()
         ]
-        sample_qs = TrtSamples.objects.filter(
-            observation_id=observation.observation_id
-        )
-
 
         samples = [
             {
@@ -4906,7 +4902,7 @@ class ObservationDataView(LoginRequiredMixin, SuperUserRequiredMixin, View):
                 "comments": sample.comments,
             }
             for sample in TrtSamples.objects.filter(
-                turtle_id=observation.turtle_id
+                observation_id=observation.observation_id
             )
         ]
 

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -5577,18 +5577,6 @@ class TurtleManagementView(LoginRequiredMixin, SuperUserRequiredMixin, TemplateV
             ]
 
             observations = turtle.trtobservations_set.select_related("place_code", "activity_code").all()
-            # observation_data = [
-            #     {
-            #         "observation_id": obs.pk,
-            #         "date_time": obs.observation_date.strftime("%Y-%m-%dT%H:%M"),
-            #         "observation_status": obs.observation_status,
-            #         "alive": str(obs.alive),
-            #         "place": obs.place_code.get_full_name() if obs.place_code else "",
-            #         "nesting": str(obs.nesting),
-            #         "activity": str(obs.activity_code),
-            #     }
-            #     for obs in observations
-            # ]
             observation_data = []
 
             for obs in observations:

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -4691,11 +4691,11 @@ class ObservationManagementView(LoginRequiredMixin, SuperUserRequiredMixin, Temp
                         {"code": "U", "description": "Unknown"},
                     ],
                     "tissue_types": [
-                        {
-                        "tissue_type": tissue.tissue_type,
-                        "description": tissue.description,
-                        }
-                        for tissue in TrtTissueTypes.objects.all()
+                    {
+                    "tissue_type": tissue.tissue_type,
+                    "description": tissue.description,
+                    }
+                    for tissue in TrtTissueTypes.objects.all()
                     ],
                     "places": TrtPlaces.objects.all(),
                     "activity_code_choices": TrtActivities.objects.all(),
@@ -4892,6 +4892,10 @@ class ObservationDataView(LoginRequiredMixin, SuperUserRequiredMixin, View):
             }
             for measurement in observation.trtmeasurements_set.all()
         ]
+        sample_qs = TrtSamples.objects.filter(
+            observation_id=observation.observation_id
+        )
+
 
         samples = [
             {
@@ -4902,7 +4906,7 @@ class ObservationDataView(LoginRequiredMixin, SuperUserRequiredMixin, View):
                 "comments": sample.comments,
             }
             for sample in TrtSamples.objects.filter(
-                observation_id=observation.observation_id
+                turtle_id=observation.turtle_id
             )
         ]
 
@@ -5608,11 +5612,6 @@ class TurtleManagementView(LoginRequiredMixin, SuperUserRequiredMixin, TemplateV
                     .filter(observation_id=obs)
                     .first()
                 )
-                print(
-                    f"obs={obs.pk}, "
-                    f"entry={entry.data_entry_id if entry else None}, "
-                    f"interrupted={entry.interrupted if entry else None}"
-                    )
 
                 observation_data.append({
                     "observation_id": obs.pk,

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -4886,6 +4886,16 @@ class ObservationDataView(LoginRequiredMixin, SuperUserRequiredMixin, View):
             for measurement in observation.trtmeasurements_set.all()
         ]
 
+        samples = [
+            {
+                "sample_id": sample.sample_id,
+                "tissue_type": sample.tissue_type.description if sample.tissue_type else "",
+                "sample_label": sample.sample_label,
+                "comments": sample.comments,
+            }
+            for sample in TrtSamples.objects.filter(observation_id=observation.observation_id)
+        ]
+
         identification_types = [
             {"identification_type": type_obj.identification_type, "description": type_obj.description}
             for type_obj in TrtIdentificationTypes.objects.all()
@@ -4933,7 +4943,9 @@ class ObservationDataView(LoginRequiredMixin, SuperUserRequiredMixin, View):
             "identification_types": identification_types,
             "body_parts": body_parts,
             "damage_codes": damage_codes,
+            "samples": samples,
         }
+        
 
     def _filter_observations(self, request):
         """Filter observations based on request parameters"""

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -4690,6 +4690,13 @@ class ObservationManagementView(LoginRequiredMixin, SuperUserRequiredMixin, Temp
                         {"code": "E", "description": "Evening"},
                         {"code": "U", "description": "Unknown"},
                     ],
+                    "tissue_types": [
+                        {
+                        "tissue_type": tissue.tissue_type,
+                        "description": tissue.description,
+                        }
+                        for tissue in TrtTissueTypes.objects.all()
+                    ],
                     "places": TrtPlaces.objects.all(),
                     "activity_code_choices": TrtActivities.objects.all(),
                     "beach_position_code_choices": TrtBeachPositions.objects.all(),
@@ -4889,11 +4896,14 @@ class ObservationDataView(LoginRequiredMixin, SuperUserRequiredMixin, View):
         samples = [
             {
                 "sample_id": sample.sample_id,
-                "tissue_type": sample.tissue_type.description if sample.tissue_type else "",
+                "tissue_type": sample.tissue_type.tissue_type,
+                "tissue_type_description": sample.tissue_type.description,
                 "sample_label": sample.sample_label,
                 "comments": sample.comments,
             }
-            for sample in TrtSamples.objects.filter(observation_id=observation.observation_id)
+            for sample in TrtSamples.objects.filter(
+                observation_id=observation.observation_id
+            )
         ]
 
         identification_types = [
@@ -5824,7 +5834,7 @@ class SamplesUpdateView(LoginRequiredMixin, SuperUserRequiredMixin, View):
                 if sample_id:
                     # Update existing sample
                     TrtSamples.objects.filter(sample_id=sample_id).update(
-                        tissue_type=sample.get("tissue_type"),
+                        tissue_type_id=sample.get("tissue_type"),
                         sample_label=sample.get("sample_label"),
                         observation_id=sample.get("observation_id"),
                         comments=sample.get("comments"),
@@ -5833,7 +5843,7 @@ class SamplesUpdateView(LoginRequiredMixin, SuperUserRequiredMixin, View):
                     # Create new sample
                     TrtSamples.objects.create(
                         turtle_id=turtle_id,
-                        tissue_type=sample.get("tissue_type"),
+                        tissue_type_id=sample.get("tissue_type"),
                         sample_label=sample.get("sample_label"),
                         observation_id=sample.get("observation_id"),
                         comments=sample.get("comments"),


### PR DESCRIPTION
## Summary

Adds a Samples tab to Observation Management so users can view and manage biopsy/sample information directly from an observation.

## Changes

- Added Samples tab to Observation Management. (Use observation-scoped sample query set when loading samples.)
- Added sample data to observation API responses.
- Display existing samples for the selected observation.
- Added support for creating, editing and deleting samples.
- Added tissue type dropdown using tissue type reference data.
- Integrated sample save functionality with the existing samples update API.

## Testing

- Verified existing samples are displayed.
- Verified tissue type descriptions are shown in the dropdown.
- Verified new samples can be added and saved.
- Verified existing samples can be updated.
- Verified samples can be deleted.
- Verified changes persist after page refresh.