### PR TITLE
T056 Reduces SQL complexity and improves query efficiency

### DIFF
--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -1255,37 +1255,24 @@ class TurtleListView(LoginRequiredMixin, PaginateMixin, ListView):
         )
         return context
 
-    # def get_queryset(self):
-    #     """
-    #     Retrieves the queryset of turtles to be displayed.
-
-    #     Returns:
-    #         QuerySet: The queryset of turtles.
-    #     """
-    #     qs = super().get_queryset()
-    #     # General-purpose search uses the `q` parameter.
-    #     if "q" in self.request.GET and self.request.GET["q"]:
-    #         q = self.request.GET["q"]
-    #         qs = qs.filter(Q(pk__icontains=q) | Q(trttags__tag_id__icontains=q) | Q(trtpittags__pittag_id__icontains=q)).distinct()
-    #     return qs.order_by("pk")
-
     def get_queryset(self):
         qs = super().get_queryset()
 
         q = self.request.GET.get("q")
 
         if q:
+            #turtle id search
             turtle_ids = set(
                 qs.filter(pk__icontains=q)
                 .values_list("pk", flat=True)
             )
-
+            #flipper tag
             turtle_ids.update(
                 qs.filter(
                     trttags__tag_id__icontains=q
                 ).values_list("pk", flat=True)
             )
-            #pit tag?
+            #pit tag
             turtle_ids.update(
                 qs.filter(
                     trtpittags__pittag_id__icontains=q

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -1285,7 +1285,7 @@ class TurtleListView(LoginRequiredMixin, PaginateMixin, ListView):
                     trttags__tag_id__icontains=q
                 ).values_list("pk", flat=True)
             )
-
+            #pit tag?
             turtle_ids.update(
                 qs.filter(
                     trtpittags__pittag_id__icontains=q

--- a/wamtram2/views.py
+++ b/wamtram2/views.py
@@ -1255,21 +1255,46 @@ class TurtleListView(LoginRequiredMixin, PaginateMixin, ListView):
         )
         return context
 
-    def get_queryset(self):
-        """
-        Retrieves the queryset of turtles to be displayed.
+    # def get_queryset(self):
+    #     """
+    #     Retrieves the queryset of turtles to be displayed.
 
-        Returns:
-            QuerySet: The queryset of turtles.
-        """
+    #     Returns:
+    #         QuerySet: The queryset of turtles.
+    #     """
+    #     qs = super().get_queryset()
+    #     # General-purpose search uses the `q` parameter.
+    #     if "q" in self.request.GET and self.request.GET["q"]:
+    #         q = self.request.GET["q"]
+    #         qs = qs.filter(Q(pk__icontains=q) | Q(trttags__tag_id__icontains=q) | Q(trtpittags__pittag_id__icontains=q)).distinct()
+    #     return qs.order_by("pk")
+
+    def get_queryset(self):
         qs = super().get_queryset()
-        # General-purpose search uses the `q` parameter.
-        if "q" in self.request.GET and self.request.GET["q"]:
-            q = self.request.GET["q"]
-            qs = qs.filter(Q(pk__icontains=q) | Q(trttags__tag_id__icontains=q) | Q(trtpittags__pittag_id__icontains=q)).distinct()
+
+        q = self.request.GET.get("q")
+
+        if q:
+            turtle_ids = set(
+                qs.filter(pk__icontains=q)
+                .values_list("pk", flat=True)
+            )
+
+            turtle_ids.update(
+                qs.filter(
+                    trttags__tag_id__icontains=q
+                ).values_list("pk", flat=True)
+            )
+
+            turtle_ids.update(
+                qs.filter(
+                    trtpittags__pittag_id__icontains=q
+                ).values_list("pk", flat=True)
+            )
+
+            qs = qs.filter(pk__in=turtle_ids)
 
         return qs.order_by("pk")
-
 
 class TurtleDetailView(LoginRequiredMixin, DetailView):
     """


### PR DESCRIPTION
## Background

The original turtle search used a single query that combined Turtle ID, Flipper Tag ID, and PIT Tag ID searches using `OR` conditions across multiple joined tables.

This generated a complex SQL query involving:

- `LEFT JOIN TRT_TAGS`
- `LEFT JOIN TRT_PIT_TAGS`
- `OR` conditions across Turtle ID, Flipper Tag ID, and PIT Tag ID
- `DISTINCT` result filtering

In the local SQL Server environment, this query produced a very inefficient execution plan and could take several minutes to return results.

## Changes

- Split Turtle ID, Flipper Tag, and PIT Tag searches into separate queries.
- Collect matching Turtle IDs from each search independently.
- Combine matching Turtle IDs in Python.
- Perform a final lookup using the combined Turtle ID list.

## Result

- Preserves existing search behaviour.
- Avoids the expensive `OR + JOIN + DISTINCT` query pattern.
- Reduces SQL complexity and improves query efficiency